### PR TITLE
Add recommendation helper and update tests

### DIFF
--- a/magic8_companion/modules/combo_scorer.py
+++ b/magic8_companion/modules/combo_scorer.py
@@ -175,5 +175,27 @@ class ComboScorer:
         # High IV bonus for premium collection
         if iv_percentile > 80 and range_pct > 0.012:
             score += 10  # Excellent vertical conditions
-        
+
         return min(score, 100)
+
+
+def generate_recommendation(scores: Dict[str, float]) -> Dict[str, str | float]:
+    """Generate combo type recommendation based on score thresholds."""
+    from magic8_companion.config import settings
+
+    if not scores:
+        return {"recommendation": "NONE", "reason": "No scores provided"}
+
+    best_combo = max(scores, key=scores.get)
+    best_score = scores[best_combo]
+
+    if best_score >= settings.min_recommendation_score:
+        second_best = sorted(scores.values())[-2] if len(scores) > 1 else 0
+        if best_score - second_best >= settings.min_score_gap:
+            return {
+                "recommendation": best_combo,
+                "score": best_score,
+                "confidence": "HIGH" if best_score >= 85 else "MEDIUM",
+            }
+
+    return {"recommendation": "NONE", "reason": "No clear favorite"}


### PR DESCRIPTION
## Summary
- implement `generate_recommendation` helper in combo_scorer
- revise combo scorer tests to use the class API

## Testing
- `pytest tests/test_combo_scorer.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6848d51fef008330a221d1350bb3f37d