### PR TITLE
docs: update env vars to M8C prefix

### DIFF
--- a/ENHANCED_INDICATORS.md
+++ b/ENHANCED_INDICATORS.md
@@ -95,10 +95,10 @@ All enhancements are configurable and can be disabled:
 
 ```python
 # .env
-ENABLE_GREEKS=true
-ENABLE_ADVANCED_GEX=true
-ENABLE_VOLUME_ANALYSIS=true
-USE_MOCK_DATA=true  # Test with mock data first
+M8C_ENABLE_GREEKS=true
+M8C_ENABLE_ADVANCED_GEX=true
+M8C_ENABLE_VOLUME_ANALYSIS=true
+M8C_USE_MOCK_DATA=true  # Test with mock data first
 ```
 
 ## Testing Strategy

--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ Key configuration options:
 - `M8C_CHECKPOINT_TIMES`: Times to run analysis
 
 Enhanced indicator options:
-- `ENABLE_GREEKS`: Enable Greeks calculations (Delta, Theta, Vega)
-- `ENABLE_ADVANCED_GEX`: Enable advanced Gamma Exposure analysis
-- `ENABLE_VOLUME_ANALYSIS`: Enable Volume/OI sentiment analysis
+- `M8C_ENABLE_GREEKS`: Enable Greeks calculations (Delta, Theta, Vega)
+- `M8C_ENABLE_ADVANCED_GEX`: Enable advanced Gamma Exposure analysis
+- `M8C_ENABLE_VOLUME_ANALYSIS`: Enable Volume/OI sentiment analysis
 
 ### 4. Test
 

--- a/REAL_MARKET_TESTING.md
+++ b/REAL_MARKET_TESTING.md
@@ -136,12 +136,12 @@ Results are saved with timestamps:
 Control the behavior with these settings:
 ```bash
 # Enable/disable enhancements
-export ENABLE_GREEKS=true
-export ENABLE_ADVANCED_GEX=true  
-export ENABLE_VOLUME_ANALYSIS=true
+export M8C_ENABLE_GREEKS=true
+export M8C_ENABLE_ADVANCED_GEX=true
+export M8C_ENABLE_VOLUME_ANALYSIS=true
 
 # Force real data (no mock)
-export USE_MOCK_DATA=false
+export M8C_USE_MOCK_DATA=false
 ```
 
 ## Next Steps

--- a/scripts/test_enhanced_indicators.py
+++ b/scripts/test_enhanced_indicators.py
@@ -24,10 +24,10 @@ async def test_enhanced_scoring():
     print("="*60)
     
     # Enable all enhancements
-    os.environ['ENABLE_GREEKS'] = 'true'
-    os.environ['ENABLE_ADVANCED_GEX'] = 'true'
-    os.environ['ENABLE_VOLUME_ANALYSIS'] = 'true'
-    os.environ['USE_MOCK_DATA'] = 'true'
+    os.environ['M8C_ENABLE_GREEKS'] = 'true'
+    os.environ['M8C_ENABLE_ADVANCED_GEX'] = 'true'
+    os.environ['M8C_ENABLE_VOLUME_ANALYSIS'] = 'true'
+    os.environ['M8C_USE_MOCK_DATA'] = 'true'
     
     # Initialize components
     scorer = EnhancedComboScorer()
@@ -109,9 +109,9 @@ async def test_enhanced_scoring():
     
     # Test with enhancements disabled
     print("\n\nTesting with enhancements disabled...")
-    os.environ['ENABLE_GREEKS'] = 'false'
-    os.environ['ENABLE_ADVANCED_GEX'] = 'false'
-    os.environ['ENABLE_VOLUME_ANALYSIS'] = 'false'
+    os.environ['M8C_ENABLE_GREEKS'] = 'false'
+    os.environ['M8C_ENABLE_ADVANCED_GEX'] = 'false'
+    os.environ['M8C_ENABLE_VOLUME_ANALYSIS'] = 'false'
     
     scorer_basic = EnhancedComboScorer()
     results_basic = scorer_basic.score_all_strategies(market_data)
@@ -178,10 +178,10 @@ def generate_mock_option_chain(spot_price):
 
 async def save_test_results():
     """Save test results to file for documentation."""
-    os.environ['ENABLE_GREEKS'] = 'true'
-    os.environ['ENABLE_ADVANCED_GEX'] = 'true'
-    os.environ['ENABLE_VOLUME_ANALYSIS'] = 'true'
-    os.environ['USE_MOCK_DATA'] = 'true'
+    os.environ['M8C_ENABLE_GREEKS'] = 'true'
+    os.environ['M8C_ENABLE_ADVANCED_GEX'] = 'true'
+    os.environ['M8C_ENABLE_VOLUME_ANALYSIS'] = 'true'
+    os.environ['M8C_USE_MOCK_DATA'] = 'true'
     
     scorer = EnhancedComboScorer()
     analyzer = MarketAnalyzer()

--- a/scripts/test_real_market_data.py
+++ b/scripts/test_real_market_data.py
@@ -34,10 +34,10 @@ async def test_real_market_data(symbols: list = None):
     print("="*60)
     
     # Enable all enhancements and real data
-    os.environ['ENABLE_GREEKS'] = 'true'
-    os.environ['ENABLE_ADVANCED_GEX'] = 'true'
-    os.environ['ENABLE_VOLUME_ANALYSIS'] = 'true'
-    os.environ['USE_MOCK_DATA'] = 'false'  # Use real data
+    os.environ['M8C_ENABLE_GREEKS'] = 'true'
+    os.environ['M8C_ENABLE_ADVANCED_GEX'] = 'true'
+    os.environ['M8C_ENABLE_VOLUME_ANALYSIS'] = 'true'
+    os.environ['M8C_USE_MOCK_DATA'] = 'false'  # Use real data
     
     # Initialize components
     scorer = EnhancedComboScorer()


### PR DESCRIPTION
## Summary
- document prefixed environment variables
- use `M8C_` env vars in test scripts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiofiles')*

------
https://chatgpt.com/codex/tasks/task_e_6848d852e5f08330ba0c126116841ae4