### PR TITLE
Filter SPY strikes to whole dollars

### DIFF
--- a/FIX_SUMMARY_JUNE_11.md
+++ b/FIX_SUMMARY_JUNE_11.md
@@ -45,6 +45,7 @@ else:
 
 ### SPY: ✅ Working
 - All strikes including half-dollar qualify using exchange fallback
+- Whole-dollar filtering applied so only valid strikes are requested
 - NaN warnings fixed
 
 ## Verification Commands

--- a/SPY_HALF_DOLLAR_FIX.md
+++ b/SPY_HALF_DOLLAR_FIX.md
@@ -84,3 +84,12 @@ the sequence is `SMART`, `CBOE`, `AMEX`, then `ISE`.  The logs show which
 exchange ultimately succeeds so we can track where half-dollar strikes are
 available.  This fallback removes the `No security definition` warnings during
 testing.
+
+### June 13 Update
+
+With exchange fallback working, half-dollar SPY strikes still generated extra requests that ultimately failed qualification. After obtaining the strike list from the option chain we now remove any values that are not whole dollars:
+```python
+if original_symbol == 'SPY':
+    all_strikes = [s for s in all_strikes if s.is_integer()]
+```
+This ensures only strikes that IBKR can qualify are requested. Logs show the filtered strike range so it's clear which strikes were kept.

--- a/magic8_companion/modules/ibkr_market_data.py
+++ b/magic8_companion/modules/ibkr_market_data.py
@@ -355,6 +355,11 @@ class IBKRMarketData:
             
             # Get ATM strike
             all_strikes = sorted([float(s) for s in selected_chain.strikes])
+            if original_symbol == 'SPY':
+                all_strikes = [s for s in all_strikes if s.is_integer()]
+                logger.debug(
+                    f"Filtered SPY strikes to whole dollars: {len(all_strikes)} available"
+                )
             atm_strike = min(all_strikes, key=lambda x: abs(x - spot_price))
             atm_index = all_strikes.index(atm_strike)
             


### PR DESCRIPTION
## Summary
- filter SPY strikes to whole dollars in IBKR data fetcher
- log the filtered strike count
- document the SPY strike filtering
- note update in fix summary

## Testing
- `python scripts/test_ibkr_market_data.py SPY` *(fails: connection refused)*
- `pytest -q` *(fails: ModuleNotFoundError: aiofiles)*

------
https://chatgpt.com/codex/tasks/task_e_6849ca004df88330a318fe54e2f0d48f