### PR TITLE
Fix async __main__ entrypoint

### DIFF
--- a/magic8_companion/__main__.py
+++ b/magic8_companion/__main__.py
@@ -3,7 +3,9 @@ Entry point for running Magic8-Companion as a module.
 Usage: python -m magic8_companion
 """
 
+import asyncio
+
 from .main import main
 
 if __name__ == "__main__":
-    main()
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- run magic8 as module using asyncio

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: aiofiles, AssertionError in tests)*
- `M8C_USE_MOCK_DATA=true python -m magic8_companion`

------
https://chatgpt.com/codex/tasks/task_e_684b51b3222c8330ae62639d31e9ddb4