### PR TITLE
Update docs and tests for multi-strategy output

### DIFF
--- a/INTEGRATION_CONTEXT.md
+++ b/INTEGRATION_CONTEXT.md
@@ -26,7 +26,25 @@ You have two interconnected trading systems that work together:
   - 18 checkpoints including every 5 minutes from 14:50-15:55
   - Supports SPX, SPY, QQQ, RUT
   - All IBKR fixes applied (NaN handling, SPY SMART routing)
-- **Output Format**: Generates recommendations with preferred_strategy, score, and confidence levels
+- **Output Format**: Generates recommendations with a `strategies` dictionary (including `should_trade`) and a `best_strategy` field
+
+Example snippet:
+
+```json
+{
+  "timestamp": "2025-06-11T14:45:00Z",
+  "recommendations": {
+    "SPX": {
+      "strategies": {
+        "Butterfly": { "score": 85.0, "confidence": "HIGH", "should_trade": true },
+        "Iron_Condor": { "score": 65.0, "confidence": "MEDIUM", "should_trade": false },
+        "Vertical": { "score": 50.0, "confidence": "LOW", "should_trade": false }
+      },
+      "best_strategy": "Butterfly"
+    }
+  }
+}
+```
 
 ### DiscordTrading (INTEGRATION READY ✅)
 - **Branch**: dev (has Magic8 integration built-in)

--- a/INTEGRATION_GUIDE.md
+++ b/INTEGRATION_GUIDE.md
@@ -44,14 +44,25 @@ Magic8-Companion generates recommendations in this format:
   "enhanced_indicators": true,
   "recommendations": {
     "SPX": {
-      "preferred_strategy": "Butterfly",
-      "score": 85.0,
-      "confidence": "HIGH",
-      "all_scores": {
-        "Butterfly": 85.0,
-        "Iron_Condor": 65.0,
-        "Vertical": 50.0
+      "strategies": {
+        "Butterfly": {
+          "score": 85.0,
+          "confidence": "HIGH",
+          "should_trade": true,
+          "rationale": "Low volatility environment (IV: 25%) with tight expected range (0.5%)"
+        },
+        "Iron_Condor": {
+          "score": 65.0,
+          "confidence": "MEDIUM",
+          "should_trade": false
+        },
+        "Vertical": {
+          "score": 50.0,
+          "confidence": "LOW",
+          "should_trade": false
+        }
       },
+      "best_strategy": "Butterfly",
       "market_conditions": {
         "iv_rank": 25.0,
         "range_expectation": 0.005,
@@ -61,8 +72,7 @@ Magic8-Companion generates recommendations in this format:
           "advanced_gex_enabled": true,
           "volume_analysis_enabled": true
         }
-      },
-      "rationale": "Low volatility environment (IV: 25%) with tight expected range (0.5%)"
+      }
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -107,14 +107,25 @@ The system outputs recommendations to `data/recommendations.json`:
   "enhanced_indicators": true,
   "recommendations": {
     "SPX": {
-      "preferred_strategy": "Butterfly",
-      "score": 85.0,
-      "confidence": "HIGH",
-      "all_scores": {
-        "Butterfly": 85.0,
-        "Iron_Condor": 65.0,
-        "Vertical": 50.0
+      "strategies": {
+        "Butterfly": {
+          "score": 85.0,
+          "confidence": "HIGH",
+          "should_trade": true,
+          "rationale": "Low volatility environment (IV: 25%) with tight expected range (0.5%)"
+        },
+        "Iron_Condor": {
+          "score": 65.0,
+          "confidence": "MEDIUM",
+          "should_trade": false
+        },
+        "Vertical": {
+          "score": 50.0,
+          "confidence": "LOW",
+          "should_trade": false
+        }
       },
+      "best_strategy": "Butterfly",
       "market_conditions": {
         "iv_rank": 25.0,
         "range_expectation": 0.005,
@@ -124,8 +135,7 @@ The system outputs recommendations to `data/recommendations.json`:
           "advanced_gex_enabled": true,
           "volume_analysis_enabled": true
         }
-      },
-      "rationale": "Low volatility environment (IV: 25%) with tight expected range (0.5%)"
+      }
     }
   }
 }

--- a/tests/test_live_data.py
+++ b/tests/test_live_data.py
@@ -71,10 +71,16 @@ async def test_live_recommendations():
         if recommendations.get("recommendations"):
             for symbol, rec in recommendations["recommendations"].items():
                 print(f"\n{symbol}:")
-                print(f"  Strategy: {rec['preferred_strategy']}")
-                print(f"  Score: {rec['score']}")
-                print(f"  Confidence: {rec['confidence']}")
-                print(f"  Rationale: {rec['rationale']}")
+                print(f"  Best Strategy: {rec['best_strategy']}")
+
+                for strat, details in rec.get("strategies", {}).items():
+                    print(f"  {strat}:")
+                    print(f"    Score: {details['score']}")
+                    print(f"    Confidence: {details['confidence']}")
+                    print(f"    Should Trade: {details['should_trade']}")
+                    if 'rationale' in details:
+                        print(f"    Rationale: {details['rationale']}")
+
                 if 'current_price' in rec.get('market_conditions', {}):
                     print(f"  Current Price: ${rec['market_conditions']['current_price']}")
                 if 'implied_vol' in rec.get('market_conditions', {}):


### PR DESCRIPTION
## Summary
- document `strategies` dictionary and `best_strategy`
- fix examples in README, INTEGRATION_GUIDE, INTEGRATION_CONTEXT
- update live data test for new recommendation structure

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and assertion failures)*

------
https://chatgpt.com/codex/tasks/task_e_684b5640021c8330bc80f044b7e5d547