### PR TITLE
Implement trading logic fixes and aggregate GEX data

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ python scripts/test_runner.py
 ./start_magic8_enhanced.sh
 ```
 
+Set the `MAGIC8_ROOT` environment variable if your repository lives outside the
+standard directory layout so the test runner can locate the project correctly.
+
 ## Output Format
 
 The system outputs recommendations to `data/recommendations.json`:

--- a/docs/CONSOLIDATED_GUIDE.md
+++ b/docs/CONSOLIDATED_GUIDE.md
@@ -117,6 +117,9 @@ python scripts/test_runner.py
 # Select option 2 for quick test
 ```
 
+If your directory layout differs, set the `MAGIC8_ROOT` environment variable to
+the Magic8-Companion folder before running the script.
+
 ## Production Workflow
 
 ### Starting the System (3 Terminals)

--- a/magic8_companion/unified_main.py
+++ b/magic8_companion/unified_main.py
@@ -103,11 +103,8 @@ class RecommendationEngine:
             confidence = self._determine_confidence(score)
             
             # Determine if this strategy should be traded
-            # Use MORE LENIENT requirements based on confidence and score
-            should_trade = (
-                confidence == "HIGH" or 
-                (confidence == "MEDIUM" and score >= settings.min_recommendation_score)
-            )
+            # Only HIGH confidence trades are executed to match documentation
+            should_trade = confidence == "HIGH"
             
             strategies[strategy] = {
                 "score": round(score, 1),

--- a/magic8_companion/wrappers/gex_wrapper.py
+++ b/magic8_companion/wrappers/gex_wrapper.py
@@ -174,9 +174,12 @@ class GammaExposureWrapper:
         strike_gex = {}
         
         for opt in options:
-            total_gamma = (opt.call_gamma * opt.call_oi + 
-                          opt.put_gamma * opt.put_oi)
-            strike_gex[opt.strike] = total_gamma
+            total_gamma = (
+                opt.call_gamma * opt.call_oi +
+                opt.put_gamma * opt.put_oi
+            )
+            # Aggregate gamma exposure for strikes that appear multiple times
+            strike_gex[opt.strike] = strike_gex.get(opt.strike, 0) + total_gamma
         
         # Sort by total gamma exposure
         sorted_strikes = sorted(strike_gex.items(), 

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,7 @@ scikit-learn==1.5.2  # For data analysis
 
 # Async HTTP for future API calls
 aiohttp==3.11.11
+aiofiles==24.1.0
 requests==2.32.3
 
 # Performance & Caching

--- a/scripts/test_runner.py
+++ b/scripts/test_runner.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python3
 """
 Magic8 Trading System - Unified Test Runner
-A single interface for all testing needs
+A single interface for all testing needs.
+
+The runner now derives project paths from the script location or an optional
+``MAGIC8_ROOT`` environment variable. Set ``MAGIC8_ROOT`` if your project lives
+outside the default directory layout.
 """
 import os
 import sys
@@ -48,9 +52,16 @@ class Magic8TestRunner:
     """Unified test runner for Magic8 trading system"""
     
     def __init__(self):
-        self.project_root = Path("/Users/jt/magic8")
-        self.magic8_path = self.project_root / "Magic8-Companion"
-        self.discord_path = self.project_root / "DiscordTrading"
+        env_root = os.environ.get("MAGIC8_ROOT")
+        if env_root:
+            self.project_root = Path(env_root).expanduser()
+        else:
+            # Assume this script lives in <root>/scripts and use that
+            self.project_root = Path(__file__).resolve().parents[1]
+
+        self.magic8_path = self.project_root
+        # DiscordTrading expected alongside Magic8-Companion
+        self.discord_path = self.project_root.parent / "DiscordTrading"
         
     def check_environment(self):
         """Check if the environment is properly set up"""

--- a/tests/test_gex_wrapper.py
+++ b/tests/test_gex_wrapper.py
@@ -1,0 +1,13 @@
+import pytest
+from magic8_companion.wrappers.gex_wrapper import GammaExposureWrapper, OptionData
+
+
+def test_find_gamma_walls_aggregates():
+    wrapper = GammaExposureWrapper()
+    options = [
+        OptionData(strike=100, call_gamma=0.5, put_gamma=0.1, call_oi=10, put_oi=20, spot_price=100),
+        OptionData(strike=100, call_gamma=0.3, put_gamma=0.2, call_oi=15, put_oi=5, spot_price=100),
+        OptionData(strike=110, call_gamma=0.4, put_gamma=0.2, call_oi=10, put_oi=10, spot_price=100),
+    ]
+    walls = wrapper._find_gamma_walls(options, top_n=2)
+    assert walls == [100, 110]

--- a/tests/test_recommendation_engine.py
+++ b/tests/test_recommendation_engine.py
@@ -1,0 +1,11 @@
+from magic8_companion.unified_main import RecommendationEngine
+
+def test_should_trade_high_only():
+    engine = RecommendationEngine()
+    scores = {"Butterfly": 80, "Iron_Condor": 65, "Vertical": 55}
+    market_data = {"iv_percentile": 30, "expected_range_pct": 0.01}
+    result = engine._build_all_recommendations(scores, market_data, "SPX")
+    strategies = result["strategies"]
+    assert strategies["Butterfly"]["should_trade"] is True
+    assert strategies["Iron_Condor"]["should_trade"] is False
+    assert strategies["Vertical"]["should_trade"] is False


### PR DESCRIPTION
## Summary
- ensure only HIGH confidence trades execute
- accumulate gamma exposure from duplicate strikes
- derive test runner paths from `MAGIC8_ROOT` or script location
- document new environment variable for the test runner
- add missing `aiofiles` dependency
- test GEX aggregation and HIGH-confidence rule

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_gex_wrapper.py tests/test_recommendation_engine.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6850adeba668833096b2ab49ab6d037a