### PR TITLE
Fix GEX wrapper and default IB provider

### DIFF
--- a/docs/ENHANCED_GAMMA_MIGRATION_GUIDE.md
+++ b/docs/ENHANCED_GAMMA_MIGRATION_GUIDE.md
@@ -121,7 +121,8 @@ M8C_GAMMA_SCHEDULER_TIMES=10:30,11:00,12:30,14:45
 M8C_GAMMA_MAX_AGE_MINUTES=5
 
 # === DATA PROVIDER ===
-M8C_DATA_PROVIDER=yahoo  # or ib, polygon
+M8C_DATA_PROVIDER=ib  # ib, yahoo, or polygon
+M8C_MARKET_DATA_PROVIDER=ib  # General market data source
 
 # === IMPORTANT: REMOVE THESE OBSOLETE SETTINGS ===
 # M8C_ML_OPTION_TRADING_PATH=../MLOptionTrading  # REMOVE THIS
@@ -190,7 +191,8 @@ M8C_GAMMA_SCHEDULER_TIMES=10:30,11:00   # Times for scheduled mode
 M8C_GAMMA_SCHEDULER_INTERVAL=5          # Minutes for interval mode
 
 # Data provider
-M8C_DATA_PROVIDER=yahoo                 # yahoo, ib, or polygon
+M8C_DATA_PROVIDER=ib                   # ib, yahoo, or polygon
+M8C_MARKET_DATA_PROVIDER=ib            # general market data
 
 # Advanced settings (optional)
 M8C_GEX_0DTE_MULTIPLIER=8.0            # 0DTE option multiplier

--- a/docs/ENHANCED_GAMMA_MIGRATION_PLAN.md
+++ b/docs/ENHANCED_GAMMA_MIGRATION_PLAN.md
@@ -4,10 +4,10 @@
 
 This document outlines the comprehensive plan to migrate the Enhanced Gamma Exposure (GEX) feature from MLOptionTrading to Magic8-Companion, creating a unified, self-contained options trading analysis system.
 
-**Migration Status**: Planning Phase  
-**Target Completion**: TBD  
-**Current State**: Both systems operational with external dependency  
-**Target State**: Magic8-Companion with native GEX implementation  
+**Migration Status**: ✅ COMPLETE
+**Target Completion**: June 2025
+**Current State**: Magic8-Companion runs native GEX without external dependencies
+**Target State**: See `ENHANCED_GAMMA_MIGRATION_GUIDE.md` for final architecture
 
 ---
 

--- a/docs/MIGRATION_STATUS_REPORT.md
+++ b/docs/MIGRATION_STATUS_REPORT.md
@@ -60,7 +60,8 @@ M8C_ENABLE_ENHANCED_GEX=true
 M8C_GAMMA_SYMBOLS=SPX                    # or SPX,SPY,QQQ
 M8C_GAMMA_SCHEDULER_MODE=scheduled
 M8C_GAMMA_SCHEDULER_TIMES=10:30,11:00,12:30,14:45
-M8C_DATA_PROVIDER=yahoo                  # or ib, polygon
+M8C_MARKET_DATA_PROVIDER=ib             # yahoo, ib, or polygon
+M8C_DATA_PROVIDER=ib                    # for gamma analysis
 ```
 
 ## Testing Checklist

--- a/magic8_companion/unified_config.py
+++ b/magic8_companion/unified_config.py
@@ -41,7 +41,7 @@ class Settings(BaseSettings):
     mock_expected_range_pct: float = 0.008  # 0.8%
     
     # Live data provider selection
-    market_data_provider: str = "yahoo"  # yahoo, ib, or polygon
+    market_data_provider: str = "ib"  # yahoo, ib, or polygon
     data_provider: str = "ib"  # For gamma analysis: ib, yahoo, polygon
     
     # Time zone

--- a/simple_gamma_enhancer.py
+++ b/simple_gamma_enhancer.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Dict, Optional
 from datetime import datetime, timedelta
 
-from magic8_companion.analysis.gamma.gamma_runner import IntegratedGammaRunner
+from magic8_companion.analysis.gamma.gamma_runner import run_gamma_analysis
 
 logger = logging.getLogger(__name__)
 
@@ -19,8 +19,7 @@ class SimpleGammaEnhancer:
     """Simple gamma enhancement for Magic8 - fully integrated"""
     
     def __init__(self):
-        # Use integrated gamma runner
-        self.gamma_runner = IntegratedGammaRunner()
+        # Use integrated native gamma analysis
         self.cache_duration_minutes = 5
         self.last_analysis = {}
         self.last_analysis_time = {}
@@ -71,7 +70,7 @@ class SimpleGammaEnhancer:
         
         # Run new analysis
         logger.info(f"Running gamma analysis for {symbol}")
-        analysis = self.gamma_runner.analyze_gamma(symbol)
+        analysis = run_gamma_analysis(symbol, save_results=False)
         
         if analysis:
             self.last_analysis[symbol] = analysis


### PR DESCRIPTION
## Summary
- use Interactive Brokers as the default market data provider
- rework `EnhancedGEXWrapper` to rely on the integrated gamma runner
- simplify `SimpleGammaEnhancer` to call the native gamma analysis
- update documentation to clarify provider settings and mark gamma plan complete

## Testing
- `python -m py_compile magic8_companion/wrappers/enhanced_gex_wrapper.py`
- `python -m py_compile simple_gamma_enhancer.py`
- `pytest tests -q` *(failures and connection errors)*

------
https://chatgpt.com/codex/tasks/task_e_6852c357207883308502ff28f9f0d1db