### PR TITLE
Improve GEX wrapper caching

### DIFF
--- a/docs/ENHANCED_GAMMA_MIGRATION_GUIDE.md
+++ b/docs/ENHANCED_GAMMA_MIGRATION_GUIDE.md
@@ -25,6 +25,9 @@ All components have been successfully migrated and implemented natively in Magic
    - Comma-separated: `M8C_GAMMA_SYMBOLS=SPX,SPY,QQQ`
    - JSON array: `M8C_GAMMA_SYMBOLS=["SPX","SPY","QQQ"]`
    - Both formats now work seamlessly
+4. **MarketAnalyzer Cache Integration**
+   - Gamma analysis now reuses cached option-chain data from `MarketAnalyzer`.
+   - UnifiedComboScorer no longer triggers a second option-chain fetch.
 
 ## What Was Migrated
 

--- a/magic8_companion/modules/unified_combo_scorer.py
+++ b/magic8_companion/modules/unified_combo_scorer.py
@@ -293,7 +293,7 @@ class UnifiedComboScorer:
             
             # Apply GEX adjustments (enhanced or standard)
             if hasattr(self, 'enhanced_gex_wrapper') or hasattr(self, 'gex_wrapper'):
-                gex_adj = await self._calculate_gex_adjustments(market_data)
+                gex_adj = await self._calculate_gex_adjustments(market_data, symbol)
                 for strategy in enhanced_scores:
                     enhanced_scores[strategy] += gex_adj.get(strategy, 0)
             
@@ -317,14 +317,17 @@ class UnifiedComboScorer:
         # Placeholder - would implement actual Greeks logic here
         return {"Butterfly": 0, "Iron_Condor": 0, "Vertical": 0}
     
-    async def _calculate_gex_adjustments(self, market_data: Dict) -> Dict[str, float]:
+    async def _calculate_gex_adjustments(self, market_data: Dict, symbol: str) -> Dict[str, float]:
         """Calculate GEX-based scoring adjustments using enhanced gamma analysis."""
         
         try:
             # Try enhanced GEX wrapper first if available
             if hasattr(self, 'enhanced_gex_wrapper'):
                 # Get gamma adjustments using integrated analysis
-                gamma_data = await self.enhanced_gex_wrapper.get_gamma_adjustments()
+                gamma_data = await self.enhanced_gex_wrapper.get_gamma_adjustments(
+                    symbol=symbol,
+                    market_data=market_data
+                )
                 
                 if gamma_data:
                     # Apply sophisticated adjustments from MLOptionTrading

--- a/tests/test_enhanced_gex_wrapper.py
+++ b/tests/test_enhanced_gex_wrapper.py
@@ -1,0 +1,69 @@
+import asyncio
+import pytest
+from magic8_companion.wrappers.enhanced_gex_wrapper import EnhancedGEXWrapper
+
+def test_wrapper_uses_market_data(monkeypatch):
+    wrapper = EnhancedGEXWrapper()
+
+    market_data = {
+        'option_chain': [
+            {'strike': 100, 'call_gamma': 0.1, 'put_gamma': 0.2, 'call_oi': 10, 'put_oi': 10, 'dte': 0}
+        ],
+        'current_price': 100
+    }
+
+    called = {'native': 0}
+
+    async def fake_run(*args, **kwargs):
+        raise AssertionError("run_gamma_analysis should not be called")
+
+    def fake_calc(self, symbol, md):
+        called['native'] += 1
+        return {
+            'symbol': symbol,
+            'timestamp': '2025-01-01T00:00:00',
+            'net_gex': 1_000_000,
+            'levels': {'zero_gamma': 99, 'call_wall': 110, 'put_wall': 90},
+            'regime_analysis': {'regime': 'positive', 'bias': 'neutral', 'confidence': 'high'},
+        }
+
+    monkeypatch.setattr('magic8_companion.wrappers.enhanced_gex_wrapper.run_gamma_analysis', fake_run)
+    monkeypatch.setattr('magic8_companion.modules.native_gex_analyzer.NativeGEXAnalyzer.calculate_gamma_exposure', fake_calc)
+
+    result = asyncio.run(wrapper.get_gamma_adjustments(symbol='SPX', market_data=market_data))
+    assert called['native'] == 1
+    assert result['gamma_metrics']['gamma_flip'] == 99
+
+def test_wrapper_uses_cache(monkeypatch):
+    wrapper = EnhancedGEXWrapper()
+
+    market_data = {
+        'option_chain': [
+            {'strike': 100, 'call_gamma': 0.1, 'put_gamma': 0.2, 'call_oi': 10, 'put_oi': 10, 'dte': 0}
+        ],
+        'current_price': 100
+    }
+
+    called = {'native': 0}
+
+    def fake_calc(self, symbol, md):
+        called['native'] += 1
+        return {
+            'symbol': symbol,
+            'timestamp': '2025-01-01T00:00:00',
+            'net_gex': 1_000_000,
+            'levels': {'zero_gamma': 99},
+            'regime_analysis': {'regime': 'positive', 'bias': 'neutral', 'confidence': 'high'},
+        }
+
+    async def fake_run(*args, **kwargs):
+        raise AssertionError("run_gamma_analysis should not be called")
+
+    monkeypatch.setattr('magic8_companion.wrappers.enhanced_gex_wrapper.run_gamma_analysis', fake_run)
+    monkeypatch.setattr('magic8_companion.modules.native_gex_analyzer.NativeGEXAnalyzer.calculate_gamma_exposure', fake_calc)
+
+    result1 = asyncio.run(wrapper.get_gamma_adjustments(symbol='SPX', market_data=market_data))
+    result2 = asyncio.run(wrapper.get_gamma_adjustments(symbol='SPX', market_data=market_data))
+
+    assert called['native'] == 1
+    assert result1 == result2


### PR DESCRIPTION
## Summary
- accept market data in `get_gamma_adjustments`
- compute gamma metrics using cached option chain
- update UnifiedComboScorer to pass market data
- document cache reuse
- add regression tests

## Testing
- `pytest tests/test_enhanced_gex_wrapper.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685300bbc93c8330b6222f185b24d653