### PR TITLE
Add ML data debug logging

### DIFF
--- a/magic8_ml_integration.py
+++ b/magic8_ml_integration.py
@@ -14,6 +14,13 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+# If logging has not yet been configured by the application, set up a basic
+# configuration that respects the M8C_LOG_LEVEL environment variable. This
+# allows debugging output from this helper when used standalone.
+if not logging.getLogger().hasHandlers():
+    _level = os.getenv("M8C_LOG_LEVEL", "INFO").upper()
+    logging.basicConfig(level=getattr(logging, _level, logging.INFO))
+
 class MLEnhancedScoring:
     """
     Drop-in replacement for Magic8-Companion scorer with ML enhancement
@@ -170,6 +177,10 @@ class MLEnhancedScoring:
                 'close': market_data['vix']
             }], index=[current_time])
             ml_data['vix_data'] = vix_data
+        logger.debug(f"ML data keys: {list(ml_data.keys())}")
+        for k, df in ml_data.items():
+            if isinstance(df, pd.DataFrame):
+                logger.debug(f"{k} shape: {df.shape}")
         
         return ml_data
     


### PR DESCRIPTION
## Summary
- enable M8C_LOG_LEVEL based logging in `magic8_ml_integration.py`
- log ML data keys and shapes in `_prepare_ml_data`

## Testing
- `pytest -q` *(fails: async functions not supported)*

------
https://chatgpt.com/codex/tasks/task_e_685acb26026c833094d61e30dad370d3