### PR TITLE
Fix scheduler thread initialization for 5-min ML

### DIFF
--- a/docs/ML_INTEGRATION_GUIDE.md
+++ b/docs/ML_INTEGRATION_GUIDE.md
@@ -727,14 +727,13 @@ class MLSchedulerExtension:
         """Start the 5-minute scheduler"""
         # Schedule ML predictions every 5 minutes
         schedule.every(5).minutes.do(self.run_ml_prediction)
-        
+
         logger.info("ML 5-minute scheduler started")
-        
-        # Run initial prediction
-        self.run_ml_prediction()
-        
+
         # Run scheduler in thread
         def run_schedule():
+            # Initial prediction now runs inside the scheduler thread
+            self.run_ml_prediction()
             while True:
                 try:
                     schedule.run_pending()

--- a/magic8_companion/ml_scheduler_extension.py
+++ b/magic8_companion/ml_scheduler_extension.py
@@ -270,9 +270,10 @@ class MLSchedulerExtension:
         """Start the 5-minute scheduler"""
         schedule.every(settings.ml_5min_interval).minutes.do(self.run_ml_prediction)
         logger.info("ML 5-minute scheduler started")
-        self.run_ml_prediction()
 
         def run_schedule():
+            # Run an initial prediction within the scheduler thread
+            self.run_ml_prediction()
             while True:
                 try:
                     schedule.run_pending()


### PR DESCRIPTION
## Summary
- move the first ML prediction into the scheduler thread so it doesn't run before the thread starts
- document the change in the integration guide

## Testing
- `pytest -q` *(fails: 32 failed, 39 passed, 2 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685ea4983bac8330978cb2997bc56620