### PR TITLE
Fix ML scheduler to use main event loop

### DIFF
--- a/docs/ML_INTEGRATION_GUIDE.md
+++ b/docs/ML_INTEGRATION_GUIDE.md
@@ -775,7 +775,8 @@ async def main():
     if settings.enable_ml_5min:
         try:
             from magic8_companion.ml_scheduler_extension import MLSchedulerExtension
-            ml_scheduler = MLSchedulerExtension()
+            loop = asyncio.get_running_loop()
+            ml_scheduler = MLSchedulerExtension(loop)
             ml_scheduler_thread = ml_scheduler.start_scheduler()
             logger.info("Phase 2: ML 5-minute scheduler started")
         except Exception as e:
@@ -1084,7 +1085,8 @@ async def test_phase2():
     # 2. Test ML scheduler import
     try:
         from magic8_companion.ml_scheduler_extension import MLSchedulerExtension
-        scheduler = MLSchedulerExtension()
+        loop = asyncio.get_running_loop()
+        scheduler = MLSchedulerExtension(loop)
         print("✓ ML scheduler initialized")
     except Exception as e:
         print(f"✗ ML scheduler failed: {e}")

--- a/magic8_companion/unified_main.py
+++ b/magic8_companion/unified_main.py
@@ -308,7 +308,8 @@ async def main():
         if settings.enable_ml_5min:
             try:
                 from magic8_companion.ml_scheduler_extension import MLSchedulerExtension
-                ml_scheduler = MLSchedulerExtension()
+                loop = asyncio.get_running_loop()
+                ml_scheduler = MLSchedulerExtension(loop)
                 ml_scheduler_thread = ml_scheduler.start_scheduler()
                 logger.info("Phase 2: ML 5-minute scheduler started")
             except Exception as e:

--- a/test_phase2_integration.py
+++ b/test_phase2_integration.py
@@ -20,7 +20,8 @@ async def test_phase2():
 
     try:
         from magic8_companion.ml_scheduler_extension import MLSchedulerExtension
-        scheduler = MLSchedulerExtension()
+        loop = asyncio.get_running_loop()
+        scheduler = MLSchedulerExtension(loop)
         print("\u2713 ML scheduler initialized")
         print(f"Using provider: {scheduler.data_provider.__class__.__name__}")
     except Exception as e:


### PR DESCRIPTION
## Summary
- allow `MLSchedulerExtension` to accept a loop
- schedule async data fetches on the main loop using `run_coroutine_threadsafe`
- pass the loop to `MLSchedulerExtension` in `unified_main.py`
- update integration guide and tests

## Testing
- `pytest -q` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_685ea92f88988330b1a2abbfd2dd2749