### PR TITLE
Handle VIX as index and document fix

### DIFF
--- a/docs/IB_CONNECTION_FIX.md
+++ b/docs/IB_CONNECTION_FIX.md
@@ -162,7 +162,10 @@ if __name__ == "__main__":
 ## VIX Data Retrieval Issues
 
 Occasionally the ML scheduler fails to fetch VIX bars from IBKR, resulting in
-errors like `Unknown contract: Stock(symbol='VIX')`. The scheduler now retries
-using Yahoo Finance when IBKR data is unavailable. If both sources fail, the
+errors like `Unknown contract: Stock(symbol='VIX')`. VIX (and SPX) must be
+requested as an **Index** contract on the CBOE exchange to qualify properly.
+Use `Index('SPX', 'CBOE', 'USD')` for SPX and `Index('VIX', 'CBOE', 'USD')` for
+VIX as shown in the sample downloader script. The scheduler now retries using
+Yahoo Finance when IBKR data is unavailable. If both sources fail, the
 prediction step is skipped until data becomes available. Check the logs for
 `VIX data fetch failed` messages when troubleshooting.

--- a/magic8_companion/modules/ib_client.py
+++ b/magic8_companion/modules/ib_client.py
@@ -82,17 +82,19 @@ class IBClient:
             'RUT': ['RUT'],
             'SPY': ['SPY'],
             'QQQ': ['QQQ'],
-            'IWM': ['IWM']
+            'IWM': ['IWM'],
+            'VIX': ['VIX']
         }.get(symbol_name, [symbol_name])
         
         # Exchange preferences
         exchange_map = {
-            'SPX': ['SMART', 'CBOE'],
-            'SPXW': ['SMART', 'CBOE'],
+            'SPX': ['CBOE', 'SMART'],
+            'SPXW': ['CBOE', 'SMART'],
             'RUT': ['SMART', 'CBOE', 'RUSSELL'],
             'SPY': ['SMART', 'CBOE', 'ARCA', 'BATS'],
             'QQQ': ['SMART', 'NASDAQ', 'CBOE'],
-            'IWM': ['SMART', 'ARCA', 'CBOE']
+            'IWM': ['SMART', 'ARCA', 'CBOE'],
+            'VIX': ['CBOE', 'SMART']
         }
         
         for sym_variant in symbol_variations:
@@ -101,7 +103,7 @@ class IBClient:
             for exchange in exchanges:
                 try:
                     # Create appropriate contract type
-                    if symbol_name in ['SPX', 'RUT']:
+                    if symbol_name in ['SPX', 'RUT', 'VIX']:
                         underlying_contract = Index(sym_variant, exchange, 'USD')
                     else:
                         underlying_contract = Stock(sym_variant, exchange, 'USD')

--- a/magic8_companion/modules/ibkr_market_data.py
+++ b/magic8_companion/modules/ibkr_market_data.py
@@ -61,17 +61,19 @@ class IBKRMarketData:
             'QQQ': ['QQQ'],             # NASDAQ 100 ETF
             'IWM': ['IWM'],             # Russell 2000 ETF
             'SPY': ['SPY'],             # S&P 500 ETF
-            'RUT': ['RUT']              # Russell 2000 Index
+            'RUT': ['RUT'],             # Russell 2000 Index
+            'VIX': ['VIX']              # Volatility Index
         }
         
         # Exchange mapping - prioritize SMART for better fills
         self.exchange_map = {
-            'SPX': ['SMART', 'CBOE'],
-            'SPXW': ['SMART', 'CBOE'],
+            'SPX': ['CBOE', 'SMART'],
+            'SPXW': ['CBOE', 'SMART'],
             'RUT': ['SMART', 'CBOE', 'RUSSELL'],
             'QQQ': ['SMART', 'NASDAQ', 'CBOE'],
             'IWM': ['SMART', 'ARCA', 'CBOE'],
-            'SPY': ['SMART', 'CBOE', 'ARCA', 'BATS']
+            'SPY': ['SMART', 'CBOE', 'ARCA', 'BATS'],
+            'VIX': ['CBOE', 'SMART']
         }
         
         # Trading class preferences for 0DTE
@@ -118,7 +120,7 @@ class IBKRMarketData:
             for exchange in exchanges:
                 try:
                     # Create appropriate contract
-                    if symbol in ['SPX', 'RUT']:
+                    if symbol in ['SPX', 'RUT', 'VIX']:
                         # Index options
                         underlying = Index(
                             symbol=sym_variant,

--- a/tests/test_vix_qualification.py
+++ b/tests/test_vix_qualification.py
@@ -1,0 +1,27 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+from ib_async import Index
+from magic8_companion.modules.ib_client import IBClient
+from magic8_companion.unified_config import settings
+
+@pytest.mark.asyncio
+async def test_vix_qualification_prefers_cboe():
+    client = IBClient()
+    mock_ib = AsyncMock()
+
+    async def qualify(contract):
+        contract.conId = 42
+        return [contract]
+
+    mock_ib.qualifyContractsAsync.side_effect = qualify
+
+    settings.enable_oi_streaming = False
+    with patch('magic8_companion.modules.ib_client.get_ib_connection', new=AsyncMock(return_value=mock_ib)):
+        contract = await client.qualify_underlying_with_fallback('VIX')
+    settings.enable_oi_streaming = True
+
+    assert isinstance(contract, Index)
+    assert contract.exchange == 'CBOE'
+    first_call = mock_ib.qualifyContractsAsync.call_args_list[0][0][0]
+    assert isinstance(first_call, Index)
+    assert first_call.exchange == 'CBOE'


### PR DESCRIPTION
## Summary
- treat VIX like an index contract when qualifying underlyings
- prioritize CBOE for SPX, SPXW and VIX exchanges
- document how to request SPX and VIX as Index contracts
- add unit test verifying that IBClient requests VIX on CBOE first

## Testing
- `pytest -q` *(fails: async def functions are not natively supported)*
- `pytest tests/test_vix_qualification.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685ed68823888330bbd057f827c3db48