### PR TITLE
Fix ML timezone bug with runtime patch

### DIFF
--- a/docs/ML_INTEGRATION_GUIDE.md
+++ b/docs/ML_INTEGRATION_GUIDE.md
@@ -1000,6 +1000,7 @@ system. The Phase 2 scheduler now strips timezone information before calling the
 ML module. If you see this error, ensure you are running the latest version and
 that `current_time` is naive UTC.
 ```
+A runtime patch (`ml_timezone_patch`) now safeguards the ML library from this error.
 
 ### Phase 2 Best Practices
 

--- a/docs/ML_SCHEDULER_TIMEZONE_FIX.md
+++ b/docs/ML_SCHEDULER_TIMEZONE_FIX.md
@@ -30,6 +30,7 @@ naive_time = datetime.utcnow()
 
 The `datetime.utcnow()` method returns a truly naive datetime in UTC, which is what the ML system expects.
 
+A runtime patch now adjusts the MLOptionTrading FeatureEngineer to handle both naive and aware datetimes. The patch is loaded automatically from `magic8_companion.patches.ml_timezone_patch`.
 ## Testing
 
 ### Running Tests Properly

--- a/magic8_companion/ml_scheduler_extension.py
+++ b/magic8_companion/ml_scheduler_extension.py
@@ -28,6 +28,8 @@ sys.path.insert(0, ML_PATH)
 # Import from MLOptionTrading
 from ml.enhanced_ml_system import ProductionMLSystem, MLConfig
 from ml.discord_data_processor import DiscordDataLoader
+from magic8_companion.patches.ml_timezone_patch import apply_patch as _apply_tz_patch
+_apply_tz_patch()
 
 # Import from Magic8-Companion
 from magic8_companion.data_providers import DataProvider

--- a/magic8_companion/patches/ml_timezone_patch.py
+++ b/magic8_companion/patches/ml_timezone_patch.py
@@ -1,0 +1,46 @@
+"""Temporary patch for MLOptionTrading timezone bug."""
+import logging
+from datetime import timedelta
+import pytz
+
+logger = logging.getLogger(__name__)
+
+
+def apply_patch():
+    try:
+        from ml.enhanced_ml_system import FeatureEngineer
+    except Exception as e:  # pragma: no cover - patch only if module present
+        logger.debug(f"ML library not available: {e}")
+        return
+
+    if getattr(FeatureEngineer.create_temporal_features, "_patched", False):
+        return
+
+    original = FeatureEngineer.create_temporal_features
+
+    def patched_create_temporal_features(self, current_time):
+        """Handle aware datetimes gracefully and avoid pytz errors."""
+        naive_time = current_time.replace(tzinfo=None) if current_time.tzinfo else current_time
+        try:
+            return original(self, naive_time)
+        except ValueError as err:
+            if "Not naive datetime" not in str(err):
+                raise
+            est_time = self.est.localize(naive_time)
+            offset_today = est_time.utcoffset() or timedelta()
+            offset_prev = (est_time - timedelta(days=1)).utcoffset() or timedelta()
+            offset_tomorrow = (est_time + timedelta(days=1)).utcoffset() or timedelta()
+            return {
+                "hour_of_day": est_time.hour,
+                "day_of_week": est_time.weekday(),
+                "offset_today": offset_today.total_seconds() / 3600,
+                "offset_prev": offset_prev.total_seconds() / 3600,
+                "offset_tomorrow": offset_tomorrow.total_seconds() / 3600,
+            }
+
+    patched_create_temporal_features._patched = True
+    FeatureEngineer.create_temporal_features = patched_create_temporal_features
+    logger.info("Applied MLOptionTrading timezone patch")
+
+
+apply_patch()

--- a/tests/test_ml_timezone_patch.py
+++ b/tests/test_ml_timezone_patch.py
@@ -1,0 +1,48 @@
+import importlib
+import sys
+import types
+import datetime
+import pytz
+
+# Create dummy ml package mimicking the bug
+ml_pkg = types.ModuleType('ml')
+enhanced = types.ModuleType('ml.enhanced_ml_system')
+
+a = pytz.timezone('US/Eastern')
+
+class DummyFeatureEngineer:
+    def __init__(self):
+        self.est = a
+    def create_temporal_features(self, current_time):
+        current_time_est = self.est.localize(current_time)
+        return {"offset": self.est.utcoffset(current_time_est).total_seconds()}
+
+class DummyMLConfig:
+    pass
+
+class DummyMLSystem:
+    def __init__(self, config):
+        self.feature_engineer = DummyFeatureEngineer()
+
+ml_pkg.enhanced_ml_system = enhanced
+enhanced.FeatureEngineer = DummyFeatureEngineer
+enhanced.MLConfig = DummyMLConfig
+enhanced.ProductionMLSystem = DummyMLSystem
+sys.modules['ml'] = ml_pkg
+sys.modules['ml.enhanced_ml_system'] = enhanced
+
+discord_mod = types.ModuleType('ml.discord_data_processor')
+discord_mod.DiscordDataLoader = object
+sys.modules['ml.discord_data_processor'] = discord_mod
+
+# Apply patch
+from magic8_companion.patches.ml_timezone_patch import apply_patch
+apply_patch()
+
+import ml.enhanced_ml_system as ems
+
+def test_timezone_patch_handles_aware_datetime():
+    fe = ems.FeatureEngineer()
+    aware = datetime.datetime.now(pytz.UTC)
+    result = fe.create_temporal_features(aware)
+    assert 'offset' in result


### PR DESCRIPTION
## Summary
- apply runtime patch for MLOptionTrading timezone error
- load patch automatically in `ml_scheduler_extension`
- document timezone patch in integration docs
- add regression test for patched behaviour

## Testing
- `pytest -q` *(fails: async def functions not supported)*

------
https://chatgpt.com/codex/tasks/task_e_685eedd357e48330a0b9becbb064ffca